### PR TITLE
replace cloud_sql_proxy with cloud-sql-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ asdf install cloud-sql-proxy latest
 asdf global cloud-sql-proxy latest
 
 # Now cloud-sql-proxy commands are available
-cloud_sql_proxy --version
+cloud-sql-proxy --version
 ```
 
 Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on how to

--- a/contributing.md
+++ b/contributing.md
@@ -6,7 +6,7 @@ Testing Locally:
 asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
 
 #
-asdf plugin test cloud-sql-proxy https://github.com/pbr0ck3r/asdf-cloud-sql-proxy.git "cloud_sql_proxy --version"
+asdf plugin test cloud-sql-proxy https://github.com/pbr0ck3r/asdf-cloud-sql-proxy.git "cloud-sql-proxy --version"
 ```
 
 Tests are automatically run in GitHub Actions on push and PR.

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -4,8 +4,8 @@ set -euo pipefail
 
 # TODO: Ensure this is the correct GitHub homepage where releases can be downloaded for cloud-sql-proxy.
 GH_REPO="https://github.com/GoogleCloudPlatform/cloud-sql-proxy"
-TOOL_NAME="cloud_sql_proxy"
-TOOL_TEST="cloud_sql_proxy --version"
+TOOL_NAME="cloud-sql-proxy"
+TOOL_TEST="cloud-sql-proxy --version"
 
 fail() {
   echo -e "asdf-$TOOL_NAME: $*"


### PR DESCRIPTION
Google have renamed `cloud_sql_proxy` to `cloud-sql-proxy`. This PR updates the executable name managed by this plugin to be consistent with that change. 